### PR TITLE
Fix directory integration

### DIFF
--- a/classes/UpdateClient.class.php
+++ b/classes/UpdateClient.class.php
@@ -6,7 +6,7 @@
  * Author: Simone Fioravanti
  * Author URI: https://software.gieffeedizioni.it
  * API Version: 2.0.0
- * Last modified on Update Manager release: 2.5.0
+ * Last modified on Update Manager release: 2.5.1
  * -----------------------------------------------------------------------------
  * This is free software released under the terms of the General Public License,
  * version 2, or later. It is distributed WITHOUT ANY WARRANTY; without even the
@@ -14,7 +14,7 @@
  * text of the license is available at https://www.gnu.org/licenses/gpl-2.0.txt.
  * -----------------------------------------------------------------------------
  * Copyright 2021,		John Alarcon (Code Potent)
- *           2021-2023,	Simone Fioravanti
+ *           2021-2024,	Simone Fioravanti
  * -----------------------------------------------------------------------------
  */
 
@@ -27,7 +27,7 @@ const UPDATE_SERVER = 'https://software.gieffeedizioni.it/';
 // EDIT: Choose what to do in ClassicPress v.2 and above.
 //       Set to true to disable UpdateClient if updates are provided
 //       using the Classicpress Plugin Directory.
-const USE_DIRECTORY = false;
+const USE_DIRECTORY = true;
 
 // EDIT: Comment this out and fill with the first part of the url
 //       of your Download link to make sure that updates
@@ -44,7 +44,11 @@ if (!defined('ABSPATH')) {
 
 // Should directory take over?
 $running_on = function_exists('classicpress_version') ? classicpress_version() : '0';
-if (USE_DIRECTORY && version_compare($running_on, '2', '>=')) {
+if (
+		USE_DIRECTORY &&
+		version_compare($running_on, '2.0.0', '>=') &&
+		is_plugin_active('classicpress-directory-integration/classicpress-directory-integration.php')
+	) {
 	return;
 }
 

--- a/classes/UpdateClient.class.php
+++ b/classes/UpdateClient.class.php
@@ -43,10 +43,9 @@ if (!defined('ABSPATH')) {
 }
 
 // Should directory take over?
-$running_on = function_exists('classicpress_version') ? classicpress_version() : '0';
 if (
 		USE_DIRECTORY &&
-		version_compare($running_on, '2.0.0', '>=') &&
+		version_compare(function_exists('classicpress_version') ? classicpress_version() : '0', '2', '>=') &&
 		is_plugin_active('classicpress-directory-integration/classicpress-directory-integration.php')
 	) {
 	return;

--- a/codepotent-update-manager.php
+++ b/codepotent-update-manager.php
@@ -4,7 +4,7 @@
  * -----------------------------------------------------------------------------
  * Plugin Name: Update Manager
  * Description: Painlessly push updates to your ClassicPress plugin users! Serve updates from GitHub, your own site, or somewhere in the cloud. 100% integrated with the ClassicPress update process; slim and performant.
- * Version: 2.5.0
+ * Version: 2.5.1
  * Requires PHP: 5.6
  * Requires CP: 1.0
  * Author: Simone Fioravanti


### PR DESCRIPTION
ClassicPress directory integration is now a plugin.
`UpdateClient.class.php` will not run if all those conditions are met:
- constant `USE_DIRECTORY` is set to `true` in `UpdateClient.class.php`
- ClassicPress is at least v2
- ClassicPress Directory Integration plugin is active